### PR TITLE
Configure middleware endpoint

### DIFF
--- a/Azure/template.json
+++ b/Azure/template.json
@@ -33,6 +33,12 @@
         },
         "MiddlewareUrl": {
             "type": "string"
+        },
+        "MiddlewareSubscriptionKey": {
+            "type": "string"
+        },
+        "MiddlewareApiBasicAuth": {
+            "type": "securestring"
         }
     },
     "variables": {
@@ -171,6 +177,14 @@
                             {
                                 "name": "Middleware:Url ",
                                 "value": "[parameters('MiddlewareUrl')]"
+                            },
+                            {
+                                "name": "Middleware:SubscriptionKey ",
+                                "value": "[parameters('MiddlewareSubscriptionKey')]"
+                            },
+                            {
+                              "name": "Middleware:ApiBasicAuth",
+                              "value": "[parameters('MiddlewareApiBasicAuth')]"
                             }
                         ]
                     },

--- a/src/SFA.DAS.Zendesk.Monitor.Function/Startup.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/Startup.cs
@@ -34,7 +34,7 @@ namespace ZenWatchFunction
             {
                 var config = s.GetRequiredService<IConfiguration>();
                 var logger = s.GetRequiredService<ILogger<LoggingHttpClientHandler>>();
-                return new MW.ApiFactory(new Uri(config["Middleware:Url"]), logger);
+                return new MW.ApiFactory(new Uri(config["Middleware:Url"]), config["Middleware:ApiBasicAuth"], logger);
             });
             builder.Services.AddTransient(s => s.GetRequiredService<MW.ApiFactory>().Create());
         }

--- a/src/SFA.DAS.Zendesk.Monitor.Function/Startup.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/Startup.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection;
-using SFA.DAS.Zendesk.Monitor;
-using ZD = SFA.DAS.Zendesk.Monitor.Zendesk;
-using MW = SFA.DAS.Zendesk.Monitor.Middleware;
 using Microsoft.Extensions.Configuration;
-using System.Linq;
-using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SFA.DAS.Zendesk.Monitor;
+using System;
+using System.Linq;
+using MW = SFA.DAS.Zendesk.Monitor.Middleware;
+using ZD = SFA.DAS.Zendesk.Monitor.Zendesk;
 
 [assembly: FunctionsStartup(typeof(ZenWatchFunction.Startup))]
 
@@ -34,7 +34,7 @@ namespace ZenWatchFunction
             {
                 var config = s.GetRequiredService<IConfiguration>();
                 var logger = s.GetRequiredService<ILogger<LoggingHttpClientHandler>>();
-                return new MW.ApiFactory(new Uri(config["Middleware:Url"]), config["Middleware:ApiBasicAuth"], logger);
+                return new MW.ApiFactory(new Uri(config["Middleware:Url"]), config["Middleware:SubscriptionKey"], config["Middleware:ApiBasicAuth"], logger);
             });
             builder.Services.AddTransient(s => s.GetRequiredService<MW.ApiFactory>().Create());
         }

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/MockMiddleware.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/MockMiddleware.cs
@@ -34,6 +34,8 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance
             admin = RestClient.For<IFluentMockServerAdmin>(server.Urls[0]);
         }
 
+        public string SubscriptionKey { get; set; }
+
         public Task PostEvent([Body] Middleware.EventWrapper body)
             => client.PostEvent(body);
 

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/ApiFactory.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/ApiFactory.cs
@@ -10,11 +10,13 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
 {
     public class ApiFactory
     {
+        private readonly string subscriptionKey;
         private readonly ILogger<LoggingHttpClientHandler> logger;
         private readonly HttpClient httpClient;
 
-        public ApiFactory(Uri url, string basicAuth, ILogger<LoggingHttpClientHandler> logger)
+        public ApiFactory(Uri url, string subscriptionKey, string basicAuth, ILogger<LoggingHttpClientHandler> logger)
         {
+            this.subscriptionKey = subscriptionKey;
             this.logger = logger;
 
             httpClient = new HttpClient(new LoggingHttpClientHandler(logger))
@@ -25,7 +27,12 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", basicAuth);
         }
 
-        public IApi Create() => new RestClient(httpClient).CreateApi();
+        public IApi Create()
+        {
+            var api = new RestClient(httpClient).CreateApi();
+            api.SubscriptionKey = subscriptionKey;
+            return api;
+        }
     }
 
     public static class ApiFactoryExtensions

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/ApiFactory.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/ApiFactory.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Serialization.ContractResolverExtentions;
 using RestEase;
 using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace SFA.DAS.Zendesk.Monitor.Middleware
 {
@@ -12,7 +13,7 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
         private readonly ILogger<LoggingHttpClientHandler> logger;
         private readonly HttpClient httpClient;
 
-        public ApiFactory(Uri url, ILogger<LoggingHttpClientHandler> logger)
+        public ApiFactory(Uri url, string basicAuth, ILogger<LoggingHttpClientHandler> logger)
         {
             this.logger = logger;
 
@@ -20,6 +21,8 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
             {
                 BaseAddress = url
             };
+
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", basicAuth);
         }
 
         public IApi Create() => new RestClient(httpClient).CreateApi();

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
@@ -5,10 +5,10 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
 {
     public interface IApi
     {
-        [Post("/event")]
+        [Delete("/ticket?subscription-key=1af517e259e34af59a8f0bbb12a9c28f")]
         Task PostEvent([Body] EventWrapper body);
 
-        [Post("/event")]
+        [Delete("/ticket?subscription-key=1af517e259e34af59a8f0bbb12a9c28f")]
         Task PostEvent([Body] EW2 body);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
@@ -5,10 +5,13 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
 {
     public interface IApi
     {
-        [Delete("/ticket?subscription-key=1af517e259e34af59a8f0bbb12a9c28f")]
+        [Query("subscription-key")]
+        string SubscriptionKey { get; set; }
+
+        [Delete("/ticket")]
         Task PostEvent([Body] EventWrapper body);
 
-        [Delete("/ticket?subscription-key=1af517e259e34af59a8f0bbb12a9c28f")]
+        [Delete("/ticket")]
         Task PostEvent([Body] EW2 body);
     }
 }


### PR DESCRIPTION
Put configuration in place for the middleware to specify the endpoint's subscription ID (live/pre-prod/etc.) and authentication - currently only a pre-written basic auth base64 hash.