### PR TITLE
Move all knowledge of tags into `SharingTickets`

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.Function/SFA.DAS.Zendesk.Monitor.Function.csproj
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/SFA.DAS.Zendesk.Monitor.Function.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
-    <UserSecretsId>6ce508b4-aab0-433d-b749-31737908c00a</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using LanguageExt;
+using Microsoft.Extensions.Configuration;
 using SFA.DAS.Zendesk.Monitor.Zendesk;
 using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System;
@@ -97,7 +98,7 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance.Fakes
 
         public Task<long[]> /*ISharingTickets.*/GetTicketsForSharing() => sharing.GetTicketsForSharing();
 
-        Task<TicketResponse> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
+        Task<Option<TicketResponse>> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
 
         Task ISharingTickets.MarkShared(Ticket ticket) => sharing.MarkShared(ticket);
 

--- a/src/SFA.DAS.Zendesk.Monitor/SFA.DAS.Zendesk.Monitor.csproj
+++ b/src/SFA.DAS.Zendesk.Monitor/SFA.DAS.Zendesk.Monitor.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/SFA.DAS.Zendesk.Monitor/SFA.DAS.Zendesk.Monitor.csproj
+++ b/src/SFA.DAS.Zendesk.Monitor/SFA.DAS.Zendesk.Monitor.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="LanguageExt.Core" Version="3.3.28" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="RestEase" Version="1.4.10" />
   </ItemGroup>

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -24,9 +24,7 @@ namespace SFA.DAS.Zendesk.Monitor
         {
             var ticket = await zendesk.GetTicketForSharing(id);
 
-            if (ticket.Ticket.Tags.Contains("pending_middleware") ||
-                ticket.Ticket.Tags.Contains("sending_middleware"))
-                await ShareTicket(ticket);
+            await ticket.IfSomeAsync(ShareTicket);
         }
 
         private async Task ShareTicket(TicketResponse ticket)

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
@@ -1,4 +1,5 @@
-﻿using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
+﻿using LanguageExt;
+using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.Zendesk.Monitor.Zendesk
@@ -7,7 +8,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
     {
         Task<long[]> GetTicketsForSharing();
 
-        Task<TicketResponse> GetTicketForSharing(long id);
+        Task<Option<TicketResponse>> GetTicketForSharing(long id);
 
         Task MarkSharing(Ticket t);
 

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
@@ -8,6 +8,15 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 {
     public class SharingTickets : ISharingTickets
     {
+        const string pendingTag = "pending_middleware";
+        const string sendingTag = "sending_middleware";
+
+        private readonly string[] Tags = new[]
+        {
+            pendingTag, 
+            sendingTag,
+        };
+
         private readonly IApi api;
 
         public SharingTickets(IApi api)
@@ -19,31 +28,37 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
         {
             var response = await api.GetTicketWithRequiredSideloads(id);
 
-            if (!response.Ticket.Tags.Intersect(new[] { "pending_middleware", "sending_middleware" }).Any()) return default;
+            if (!TicketContainsSharingTag(response.Ticket)) return default;
 
             response.Comments = (await api.GetTicketComments(id)).Comments;
             return response;
         }
 
+        private bool TicketContainsSharingTag(Ticket ticket)
+        {
+            return ticket.Tags.Intersect(Tags).Any();
+        }
+
         public async Task<long[]> GetTicketsForSharing()
         {
-            var response = await api.SearchTickets("tags:pending_middleware tags:sending_middleware");
+            var search = string.Join(" ", Tags.Select(x => $"tags:{x}"));
+            var response = await api.SearchTickets(search);
             return response?.Results?
-                .Where(x => x.Tags.Contains("pending_middleware"))
+                .Where(TicketContainsSharingTag)
                 .Select(x => x.Id).ToArray()
                 ?? new long[] { };
         }
 
         public Task MarkSharing(Ticket t)
         {
-            t.Tags.Remove("pending_middleware");
-            t.Tags.Add("sending_middleware");
+            t.Tags.Remove(pendingTag);
+            t.Tags.Add(sendingTag);
             return api.PutTicket(t);
         }
 
         public Task MarkShared(Ticket t)
         {
-            t.Tags.Remove("sending_middleware");
+            t.Tags.Remove(sendingTag);
             return api.PutTicket(t);
         }
     }


### PR DESCRIPTION
Knowledge about the tag names was distributed through at least two classes.  Move it all into one place.