### PR TITLE
Trim payload to middleware to just the expected fields

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.Function/SFA.DAS.Zendesk.Monitor.Function.v3.ncrunchproject
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/SFA.DAS.Zendesk.Monitor.Function.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using Xunit;
+
+namespace SFA.DAS.Zendesk.Monitor.UnitTests
+{
+    public class MappingProfileTests
+    {
+        [Fact]
+        public void TestProfileIsValid()
+        {
+            var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<TicketProfile>());
+            mapperConfig.AssertConfigurationIsValid();
+        }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -41,8 +41,21 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var mwt = new { Ticket = ticket };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt, c => c.Excluding(p => p.Ticket.Tags))));
+            var expectedTicket = new
+            {
+                Ticket = new
+                {
+                    ticket.Id,
+                    ticket.Status,
+                    ticket.Description,
+                    ticket.Subject,
+                    ticket.CreatedAt,
+                }
+            };
+
+            await middleware.Received().PostEvent(
+                Verify.That<Middleware.EventWrapper>(x =>
+                    x.Should().BeEquivalentTo(expectedTicket)));
         }
 
         [Theory, AutoDataDomain]
@@ -53,7 +66,20 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var mwt = new { Ticket = new { Comments = comments } };
+            var mwt = new
+            {
+                Ticket = new
+                {
+                    Comments = comments.Select(c =>
+                    new
+                    {
+                        c.Id,
+                        c.Body,
+                        c.CreatedAt,
+                    }),
+                }
+            };
+
             await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
@@ -66,7 +92,29 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var mwt = new { Ticket = new { Requester = reporter } };
+            var mwt = new
+            {
+                Ticket = new
+                {
+                    Requester = new
+                    {
+                        reporter.Id,
+                        reporter.Name,
+                        reporter.Email,
+                        reporter.Phone,
+                        UserFields = new
+                        {
+                            reporter.UserFields.AddressLine1,
+                            reporter.UserFields.AddressLine2,
+                            reporter.UserFields.AddressLine3,
+                            reporter.UserFields.City,
+                            reporter.UserFields.County,
+                            reporter.UserFields.Postcode,
+                        }
+                    }
+                }
+            };
+
             await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
@@ -79,7 +127,27 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var mwt = new { Ticket = new { Organization = org } };
+            var mwt = new
+            {
+                Ticket = new
+                {
+                    Organization = new
+                    {
+                        org.Id,
+                        org.Name,
+                        OrganizationFields = new
+                        {
+                            org.OrganizationFields.AddressLine1,
+                            org.OrganizationFields.AddressLine2,
+                            org.OrganizationFields.AddressLine3,
+                            org.OrganizationFields.City,
+                            org.OrganizationFields.County,
+                            org.OrganizationFields.Postcode,
+                        }
+                    }
+                }
+            };
+
             await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
@@ -92,8 +160,9 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var mwt = new { Ticket = ticket };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt, c => c.Excluding(p => p.Ticket.Tags))));
+            await middleware.Received().PostEvent(
+                Verify.That<Middleware.EventWrapper>(x =>
+                    x.Should().BeEquivalentTo(new { Ticket = new { ticket.Id } })));
         }
 
         [Theory, AutoDataDomain]

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -41,10 +41,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Ticket.Should().BeEquivalentTo(ticket)));
-
             var mwt = new { Ticket = ticket };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EW2>(x => x.Should().BeEquivalentTo(mwt, c => c.Excluding(p => p.Ticket.Tags))));
+            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt, c => c.Excluding(p => p.Ticket.Tags))));
         }
 
         [Theory, AutoDataDomain]
@@ -55,11 +53,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var middlewareTicket = new Middleware.EventWrapper { Ticket = ticket, Comments = comments };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(middlewareTicket)));
-
             var mwt = new { Ticket = new { Comments = comments } };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EW2>(x => x.Should().BeEquivalentTo(mwt)));
+            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
         [Theory, AutoDataDomain]
@@ -71,11 +66,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var middlewareTicket = new Middleware.EventWrapper { Ticket = ticket, Requester = reporter };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(middlewareTicket)));
-
             var mwt = new { Ticket = new { Requester = reporter } };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EW2>(x => x.Should().BeEquivalentTo(mwt)));
+            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
         [Theory, AutoDataDomain]
@@ -87,11 +79,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            var middlewareTicket = new Middleware.EventWrapper { Ticket = ticket, Organization = org };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(middlewareTicket)));
-
             var mwt = new { Ticket = new { Organization = org } };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EW2>(x => x.Should().BeEquivalentTo(mwt)));
+            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
         [Theory, AutoDataDomain]
@@ -103,10 +92,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Ticket.Should().BeEquivalentTo(ticket)));
-
             var mwt = new { Ticket = ticket };
-            await middleware.Received().PostEvent(Verify.That<Middleware.EW2>(x => x.Should().BeEquivalentTo(mwt, c => c.Excluding(p => p.Ticket.Tags))));
+            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt, c => c.Excluding(p => p.Ticket.Tags))));
         }
 
         [Theory, AutoDataDomain]
@@ -131,7 +118,6 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             await sut.ShareTicket(ticket.Id);
 
             await middleware.DidNotReceive().PostEvent(Arg.Any<Middleware.EventWrapper>());
-            await middleware.DidNotReceive().PostEvent(Arg.Any<Middleware.EW2>());
         }
 
         private class AutoDataDomainAttribute : AutoDataAttribute

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/MockMiddleware.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/MockMiddleware.cs
@@ -39,9 +39,6 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance
         public Task PostEvent([Body] Middleware.EventWrapper body)
             => client.PostEvent(body);
 
-        public Task PostEvent([Body] EW2 body)
-            => client.PostEvent(body);
-
         public async Task<IReadOnlyList<Zendesk.Model.Ticket>> TicketEvents()
         {
             var entries = await admin.GetRequestsAsync();

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests.v3.ncrunchproject
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
+  </Settings>
+</ProjectConfiguration>

--- a/src/SFA.DAS.Zendesk.Monitor.v3.ncrunchsolution
+++ b/src/SFA.DAS.Zendesk.Monitor.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/EventWrapper.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/EventWrapper.cs
@@ -1,21 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using SFA.DAS.Zendesk.Monitor.Middleware.Model;
 
 namespace SFA.DAS.Zendesk.Monitor.Middleware
 {
     public class EventWrapper
     {
-        public EventWrapper2 Ticket { get; set; }
-    }
-
-    public class EventWrapper2 : Zendesk.Model.Ticket
-    {
-        public Zendesk.Model.Comment[] Comments { get; set; } = new Zendesk.Model.Comment[] { };
-
-        public Zendesk.Model.User Requester { get; set; }
-
-        public Zendesk.Model.Organization Organization { get; set; }
-
-        public override string ToString()
-            => JsonConvert.SerializeObject(this, Formatting.Indented);
+        public Ticket Ticket { get; set; }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/EventWrapper.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/EventWrapper.cs
@@ -4,20 +4,6 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
 {
     public class EventWrapper
     {
-        public Zendesk.Model.Ticket Ticket { get; set; }
-
-        public Zendesk.Model.Comment[] Comments { get; set; } = new Zendesk.Model.Comment[] { };
-
-        public Zendesk.Model.User Requester { get; set; }
-
-        public Zendesk.Model.Organization Organization { get; set; }
-
-        public override string ToString()
-            => JsonConvert.SerializeObject(this, Formatting.Indented);
-    }
-
-    public class EW2
-    {
         public EventWrapper2 Ticket { get; set; }
     }
 

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
@@ -10,8 +10,5 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
 
         [Delete("/ticket")]
         Task PostEvent([Body] EventWrapper body);
-
-        [Delete("/ticket")]
-        Task PostEvent([Body] EW2 body);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Comments.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Comments.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class Comments
+    {
+        public long Id { get; set; }
+        public string Body { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/CustomField.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/CustomField.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class CustomField
+    {
+        public long Id { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Organisation.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Organisation.cs
@@ -4,6 +4,6 @@
     {
         public long Id { get; set; }
         public string Name { get; set; }
-        public OrganisationFields OrganizationFields { get; set; }
+        public OrganizationFields OrganizationFields { get; set; }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Organisation.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Organisation.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class Organisation
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public OrganisationFields OrganizationFields { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/OrganisationFields.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/OrganisationFields.cs
@@ -1,0 +1,15 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class OrganisationFields
+    {
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressLine3 { get; set; }
+        public string City { get; set; }
+        public string County { get; set; }
+        public string Postcode { get; set; }
+        public string OrganizationType { get; set; }
+        public string MainPhone { get; set; }
+        public string OrganizationStatus { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/OrganisationFields.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/OrganisationFields.cs
@@ -1,6 +1,6 @@
 ﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
 {
-    public class OrganisationFields
+    public class OrganizationFields
     {
         public string AddressLine1 { get; set; }
         public string AddressLine2 { get; set; }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Ticket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Ticket.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class Ticket
+    {
+        public long Id { get; set; }
+        public string Status { get; set; }
+        public string Description { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public string Subject { get; set; }
+        public Comments[] Comments { get; set; }
+        public CustomField[] CustomFields { get; set; }
+        public Organisation Organization { get; set; }
+        public User Requester { get; set; }
+
+        public override string ToString()
+            => JsonConvert.SerializeObject(this, Formatting.Indented);
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/User.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/User.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class User
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+        public string Phone { get; set; }
+        public UserFields UserFields { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/UserFields.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/UserFields.cs
@@ -1,0 +1,13 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class UserFields
+    {
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressLine3 { get; set; }
+        public string City { get; set; }
+        public string County { get; set; }
+        public string Postcode { get; set; }
+        public string ContactType { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -1,0 +1,37 @@
+﻿using AutoMapper;
+using System.Linq;
+
+namespace SFA.DAS.Zendesk.Monitor
+{
+    public class TicketProfile : Profile
+    {
+        public TicketProfile()
+        {
+            CreateMap<Zendesk.Model.TicketResponse, Middleware.EventWrapper>()
+                .ForMember(x => x.Ticket, x => x.MapFrom(y => y.Ticket))
+                .ForPath(x => x.Ticket.Comments, x => x.MapFrom(y => y.Comments))
+                .ForPath(x => x.Ticket.Requester, x => x.MapFrom(y => FindRequester(y)))
+                .ForPath(x => x.Ticket.Organization, x => x.MapFrom(y => FindOrganisation(y)))
+                ;
+
+            CreateMap<Zendesk.Model.Ticket, Middleware.Model.Ticket>()
+                .ForMember(x => x.Comments, x => x.Ignore())
+                .ForMember(x => x.Requester, x => x.Ignore())
+                .ForMember(x => x.Organization, x => x.Ignore())
+                ;
+
+            CreateMap<Zendesk.Model.Comment, Middleware.Model.Comments>();
+            CreateMap<Zendesk.Model.Field, Middleware.Model.CustomField>();
+            CreateMap<Zendesk.Model.User, Middleware.Model.User>();
+            CreateMap<Zendesk.Model.Organization, Middleware.Model.Organisation>();
+            CreateMap<Zendesk.Model.UserFields, Middleware.Model.UserFields>();
+            CreateMap<Zendesk.Model.OrganizationFields, Middleware.Model.OrganizationFields>();
+        }
+
+        private Zendesk.Model.Organization FindOrganisation(Zendesk.Model.TicketResponse response)
+            => response.Organizations?.FirstOrDefault(x => x.Id == response.Ticket.OrganizationId);
+
+        private Zendesk.Model.User FindRequester(Zendesk.Model.TicketResponse response)
+            => response.Users?.FirstOrDefault(x => x.Id == response.Ticket.RequesterId);
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -1,16 +1,18 @@
 ﻿using AutoMapper;
 using SFA.DAS.Zendesk.Monitor.Zendesk;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.Zendesk.Monitor
 {
     public class Watcher
     {
+        private static readonly IMapper MapperConfig =
+            new MapperConfiguration(c => c.AddProfile<TicketProfile>())
+                .CreateMapper();
+
         private readonly ISharingTickets zendesk;
         private readonly Middleware.IApi middleware;
-        private static readonly IMapper MapperConfig = CreateMapperConfig();
 
         public Watcher(ISharingTickets zendesk, Middleware.IApi middleware)
         {
@@ -31,36 +33,10 @@ namespace SFA.DAS.Zendesk.Monitor
         {
             await zendesk.MarkSharing(ticket.Ticket);
 
-            var we2 = MapperConfig.Map<Middleware.Model.Ticket>(ticket.Ticket);
-            we2.Comments = MapperConfig.Map<Middleware.Model.Comments[]>(ticket.Comments);
-            we2.Requester = MapperConfig.Map<Middleware.Model.User>(ticket.Users?.FirstOrDefault(x => x.Id == ticket.Ticket.RequesterId));
-            we2.Organization = MapperConfig.Map<Middleware.Model.Organisation>(ticket.Organizations?.FirstOrDefault(x => x.Id == ticket.Ticket.OrganizationId));
+            var wrap = MapperConfig.Map<Middleware.EventWrapper>(ticket);
+            await middleware.PostEvent(wrap);
 
-            await middleware.PostEvent(new Middleware.EventWrapper { Ticket = we2 });
             await zendesk.MarkShared(ticket.Ticket);
-        }
-
-        private static IMapper CreateMapperConfig()
-        {
-            return new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<Zendesk.Model.Ticket, Middleware.Model.Ticket>()
-                    .ForMember(x => x.CustomFields, x => x.Ignore());
-
-                cfg.CreateMap<Zendesk.Model.User, Middleware.Model.User>()
-                    .ForMember(x => x.UserFields, x => x.MapFrom(y => y.UserFields));
-
-                cfg.CreateMap<Zendesk.Model.UserFields, Middleware.Model.UserFields>();
-
-                cfg.CreateMap<Zendesk.Model.Organization, Middleware.Model.Organisation>()
-                    .ForMember(x => x.OrganizationFields, x => x.MapFrom(y => y.OrganizationFields))
-                    ;
-
-                cfg.CreateMap<Zendesk.Model.OrganisationFields, Middleware.Model.OrganisationFields>();
-
-                cfg.CreateMap<Zendesk.Model.Comment, Middleware.Model.Comments>();
-
-            }).CreateMapper();
         }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -1,6 +1,5 @@
 ﻿using AutoMapper;
 using SFA.DAS.Zendesk.Monitor.Zendesk;
-using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +10,7 @@ namespace SFA.DAS.Zendesk.Monitor
     {
         private readonly ISharingTickets zendesk;
         private readonly Middleware.IApi middleware;
+        private static readonly IMapper MapperConfig = CreateMapperConfig();
 
         public Watcher(ISharingTickets zendesk, Middleware.IApi middleware)
         {
@@ -27,17 +27,40 @@ namespace SFA.DAS.Zendesk.Monitor
             await ticket.IfSomeAsync(ShareTicket);
         }
 
-        private async Task ShareTicket(TicketResponse ticket)
+        private async Task ShareTicket(Zendesk.Model.TicketResponse ticket)
         {
             await zendesk.MarkSharing(ticket.Ticket);
 
-            var am = new MapperConfiguration(cfg => cfg.CreateMap<Ticket, Middleware.EventWrapper2>()).CreateMapper();
-            var we2 = am.Map<Middleware.EventWrapper2>(ticket.Ticket);
-            we2.Comments = ticket.Comments;
-            we2.Requester = ticket.Users?.FirstOrDefault(x => x.Id == ticket.Ticket.RequesterId);
-            we2.Organization = ticket.Organizations?.FirstOrDefault(x => x.Id == ticket.Ticket.OrganizationId);
+            var we2 = MapperConfig.Map<Middleware.Model.Ticket>(ticket.Ticket);
+            we2.Comments = MapperConfig.Map<Middleware.Model.Comments[]>(ticket.Comments);
+            we2.Requester = MapperConfig.Map<Middleware.Model.User>(ticket.Users?.FirstOrDefault(x => x.Id == ticket.Ticket.RequesterId));
+            we2.Organization = MapperConfig.Map<Middleware.Model.Organisation>(ticket.Organizations?.FirstOrDefault(x => x.Id == ticket.Ticket.OrganizationId));
+
             await middleware.PostEvent(new Middleware.EventWrapper { Ticket = we2 });
             await zendesk.MarkShared(ticket.Ticket);
+        }
+
+        private static IMapper CreateMapperConfig()
+        {
+            return new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Zendesk.Model.Ticket, Middleware.Model.Ticket>()
+                    .ForMember(x => x.CustomFields, x => x.Ignore());
+
+                cfg.CreateMap<Zendesk.Model.User, Middleware.Model.User>()
+                    .ForMember(x => x.UserFields, x => x.MapFrom(y => y.UserFields));
+
+                cfg.CreateMap<Zendesk.Model.UserFields, Middleware.Model.UserFields>();
+
+                cfg.CreateMap<Zendesk.Model.Organization, Middleware.Model.Organisation>()
+                    .ForMember(x => x.OrganizationFields, x => x.MapFrom(y => y.OrganizationFields))
+                    ;
+
+                cfg.CreateMap<Zendesk.Model.OrganisationFields, Middleware.Model.OrganisationFields>();
+
+                cfg.CreateMap<Zendesk.Model.Comment, Middleware.Model.Comments>();
+
+            }).CreateMapper();
         }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -30,20 +30,13 @@ namespace SFA.DAS.Zendesk.Monitor
         private async Task ShareTicket(TicketResponse ticket)
         {
             await zendesk.MarkSharing(ticket.Ticket);
-            await middleware.PostEvent(new Middleware.EventWrapper
-            {
-                Ticket = ticket.Ticket,
-                Comments = ticket.Comments,
-                Requester = ticket.Users?.FirstOrDefault(x => x.Id == ticket.Ticket.RequesterId),
-                Organization = ticket.Organizations?.FirstOrDefault(x => x.Id == ticket.Ticket.OrganizationId),
-            });
 
             var am = new MapperConfiguration(cfg => cfg.CreateMap<Ticket, Middleware.EventWrapper2>()).CreateMapper();
             var we2 = am.Map<Middleware.EventWrapper2>(ticket.Ticket);
             we2.Comments = ticket.Comments;
             we2.Requester = ticket.Users?.FirstOrDefault(x => x.Id == ticket.Ticket.RequesterId);
             we2.Organization = ticket.Organizations?.FirstOrDefault(x => x.Id == ticket.Ticket.OrganizationId);
-            await middleware.PostEvent(new Middleware.EW2 { Ticket = we2 });
+            await middleware.PostEvent(new Middleware.EventWrapper { Ticket = we2 });
             await zendesk.MarkShared(ticket.Ticket);
         }
     }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Organization.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Organization.cs
@@ -30,6 +30,6 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk.Model
 
         public object[] Tags { get; set; }
 
-        public OrganisationFields OrganizationFields { get; set; }
+        public OrganizationFields OrganizationFields { get; set; }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/OrganizationFields.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/OrganizationFields.cs
@@ -1,6 +1,6 @@
 ﻿namespace SFA.DAS.Zendesk.Monitor.Zendesk.Model
 {
-    public partial class OrganisationFields
+    public class OrganizationFields
     {
         public object AccountManager { get; set; }
 
@@ -20,9 +20,9 @@
 
         public long? MainPhone { get; set; }
 
-        public string OrganisationStatus { get; set; }
+        public string OrganizationStatus { get; set; }
 
-        public string OrganisationType { get; set; }
+        public string OrganizationType { get; set; }
 
         public string Postcode { get; set; }
     }


### PR DESCRIPTION
The middleware is particularly picky about the payload it receives, and will silently ignore messages that contain fields it is not expecting.

This PR matches our middleware model to the middleware's schema and allows messages sent to the middleware to be processed correctly.