### PR TITLE
Escalate tickets to middleware

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,11 @@ steps:
   inputs:
     updateAssemblyInfo: true
 
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '3.x'
+
 - task: DotNetCoreCLI@2
   displayName: Restore
   inputs:

--- a/src/SFA.DAS.Zendesk.Monitor.Function/SFA.DAS.Zendesk.Monitor.Function.csproj
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/SFA.DAS.Zendesk.Monitor.Function.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/SFA.DAS.Zendesk.Monitor.Function/ZenWatchDurableFunction.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/ZenWatchDurableFunction.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -34,7 +33,7 @@ namespace ZenWatchFunction
             var ticket = JsonConvert.DeserializeObject<NotifyTicket>(content);
 
             var ids = new[] { ticket.Id };
-            log.LogInformation("NotifyTicket {id}", ids);
+            log.LogDebug("NotifyTicket {id}", ids);
 
             var instanceId = await starter.StartNewAsync(nameof(ShareListedTickets), ids);
             return starter.CreateCheckStatusResponse(request, instanceId);
@@ -55,12 +54,12 @@ namespace ZenWatchFunction
 
             if (instance?.OrchestrationIsRunning() != true)
             {
-                log.LogDebug("Starting Watcher orchestration");
+                log.LogInformation("Starting Watcher orchestration");
                 await starter.StartNewAsync(nameof(ShareAllTickets), WatcherInstance, null);
             }
             else
             {
-                log.LogDebug("Watcher orchestration is already running");
+                log.LogWarning("Watcher orchestration is already running");
             }
 
             return instance;
@@ -73,7 +72,6 @@ namespace ZenWatchFunction
 
             foreach (var ticket in tickets)
                 await context.CallActivityWithRetryAsync(nameof(DurableWatcher.ShareTicket), retry, ticket);
-            //await context.CallActivityAsync(nameof(ShareListedTickets2), tickets);
         }
 
         [FunctionName(nameof(ShareListedTickets))]

--- a/src/SFA.DAS.Zendesk.Monitor.Function/ZenWatchDurableFunction.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/ZenWatchDurableFunction.cs
@@ -29,7 +29,8 @@ namespace ZenWatchFunction
             [OrchestrationClient]DurableOrchestrationClient starter,
             ILogger log)
         {
-            var content = await new StreamReader(request.Body).ReadToEndAsync();
+            using var reader = new StreamReader(request.Body);
+            var content = await reader.ReadToEndAsync();
             var ticket = JsonConvert.DeserializeObject<NotifyTicket>(content);
 
             var ids = new[] { ticket.Id };

--- a/src/SFA.DAS.Zendesk.Monitor.Function/ZenWatchDurableFunction.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/ZenWatchDurableFunction.cs
@@ -71,7 +71,9 @@ namespace ZenWatchFunction
         {
             var tickets = await context.CallActivityAsync<long[]>(nameof(DurableWatcher.SearchTickets), null);
 
-            await context.CallActivityAsync(nameof(ShareListedTickets), tickets);
+            foreach (var ticket in tickets)
+                await context.CallActivityWithRetryAsync(nameof(DurableWatcher.ShareTicket), retry, ticket);
+            //await context.CallActivityAsync(nameof(ShareListedTickets2), tickets);
         }
 
         [FunctionName(nameof(ShareListedTickets))]

--- a/src/SFA.DAS.Zendesk.Monitor.Function/host.json
+++ b/src/SFA.DAS.Zendesk.Monitor.Function/host.json
@@ -10,7 +10,7 @@
     "logLevel": {
       "default": "Information",
       "Host.Results": "Error",
-      "Function": "Error",
+      "Function": "Information",
       "Host.Aggregator": "Trace"
     }
   }

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
@@ -1,4 +1,7 @@
 ﻿using AutoMapper;
+using FluentAssertions;
+using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
+using System.Collections.Generic;
 using Xunit;
 
 namespace SFA.DAS.Zendesk.Monitor.UnitTests
@@ -10,6 +13,55 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         {
             var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<TicketProfile>());
             mapperConfig.AssertConfigurationIsValid();
+        }
+
+        public static IEnumerable<object[]> ViaTestData => new List<object[]>
+        {
+            new object[] 
+            { 
+                new Via
+                {
+                    Channel = "voice",
+                    Source = new Source { Rel = "inbound", },
+                },
+                "Phone call (inbound)"
+            },
+            new object[] 
+            { 
+                new Via
+                {
+                    Channel = "voice",
+                    Source = new Source { Rel = "outbound", },
+                },
+                "Phone call (outbound)"
+            },
+            new object[] 
+            { 
+                new Via {Channel = "email"},
+                "Mail"
+            },
+            new object[]
+            {
+                new Via { Channel = "chat" },
+                "Chat"
+            },
+            new object[] 
+            { 
+                new Via { Channel = "web" },
+                "Web Form"
+            },
+        };
+
+        [Theory, MemberData(nameof(ViaTestData))]
+        public void TestViaMapping(Via via, string viaText)
+        {
+            var mapper = new MapperConfiguration(cfg => cfg.AddProfile<TicketProfile>()).CreateMapper();
+
+            var ticket = new Ticket { Via = via };
+
+            var mapped = mapper.Map<Middleware.Model.Ticket>(ticket);
+
+            mapped.Via.Should().Be(viaText);
         }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/PendingAttribute.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/PendingAttribute.cs
@@ -27,16 +27,23 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests.AutoFixture
         {
             if (parameter.ParameterType != typeof(Ticket))
                 throw new InvalidOperationException($"`{parameter.ParameterType.Name}` is not a valid type for [Pending].");
-            return new PendingTicketCustomisation();
+            return new PendingTicketCustomisation(solved);
         }
 
         private class PendingTicketCustomisation : ICustomization
         {
+            private string reason;
+
+            public PendingTicketCustomisation(As reason)
+            {
+                this.reason = reason.ToString().ToLower();
+            }
+
             public void Customize(IFixture fixture)
             {
                 fixture.Customize<Ticket>(x => x
                     .Without(y => y.Tags)
-                    .Do(y => y.Tags = new List<string> { "pending_middleware" }));
+                    .Do(y => y.Tags = new List<string> { $"pending_middleware_{reason}" }));
             }
         }
     }

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/PendingAttribute.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/PendingAttribute.cs
@@ -7,9 +7,22 @@ using System.Reflection;
 
 namespace SFA.DAS.Zendesk.Monitor.UnitTests.AutoFixture
 {
+    public enum As
+    {
+        Solved,
+        Escalated,
+    }
+
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
     public class PendingAttribute : CustomizeAttribute
     {
+        private As solved;
+
+        public PendingAttribute(As solved)
+        {
+            this.solved = solved;
+        }
+
         public override ICustomization GetCustomization(ParameterInfo parameter)
         {
             if (parameter.ParameterType != typeof(Ticket))

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Searching_for_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Searching_for_tickets.cs
@@ -15,8 +15,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
     {
         public static object[] Tags = new[]
         {
-            new[] { "pending_middleware" },
-            new[] { "sending_middleware" },
+            new[] { "pending_middleware_solved" },
+            new[] { "sending_middleware_solved" },
         };
 
         [Theory]

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Searching_for_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Searching_for_tickets.cs
@@ -17,6 +17,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         {
             new[] { "pending_middleware_solved" },
             new[] { "sending_middleware_solved" },
+            new[] { "pending_middleware_escalated" },
+            new[] { "sending_middleware_escalated" },
         };
 
         [Theory]

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -59,6 +59,18 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
+        public async Task Sends_ticket_to_correct_endpoint([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Escalated)] Ticket ticket)
+        {
+            zendesk.Tickets.Add(ticket);
+
+            await sut.ShareTicket(ticket.Id);
+
+            await middleware.Received().EscalateTicket(
+                Verify.That<Middleware.EventWrapper>(x =>
+                    x.Should().BeEquivalentTo(new { Ticket = new { ticket.Id } })));
+        }
+
+        [Theory, AutoDataDomain]
         public async Task Sends_ticket_to_middleware_with_comments([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket, Comment[] comments)
         {
             zendesk.Tickets.Add(ticket);

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         public async Task Marks_ticket_as_sharing_before_sending_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket)
         {
             zendesk.Tickets.Add(ticket);
-            middleware.When(x => x.PostEvent(Arg.Any<Middleware.EventWrapper>()))
+            middleware.When(x => x.SolveTicket(Arg.Any<Middleware.EventWrapper>()))
                 .Do(x => { throw new Exception("Stop test at Middleware step"); });
 
             try
@@ -53,7 +53,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 }
             };
 
-            await middleware.Received().PostEvent(
+            await middleware.Received().SolveTicket(
                 Verify.That<Middleware.EventWrapper>(x =>
                     x.Should().BeEquivalentTo(expectedTicket)));
         }
@@ -80,7 +80,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 }
             };
 
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
+            await middleware.Received().SolveTicket(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
         [Theory, AutoDataDomain]
@@ -115,7 +115,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 }
             };
 
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
+            await middleware.Received().SolveTicket(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
         [Theory, AutoDataDomain]
@@ -148,7 +148,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 }
             };
 
-            await middleware.Received().PostEvent(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
+            await middleware.Received().SolveTicket(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
         [Theory, AutoDataDomain]
@@ -160,7 +160,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            await middleware.Received().PostEvent(
+            await middleware.Received().SolveTicket(
                 Verify.That<Middleware.EventWrapper>(x =>
                     x.Should().BeEquivalentTo(new { Ticket = new { ticket.Id } })));
         }
@@ -186,7 +186,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             await sut.ShareTicket(ticket.Id);
 
-            await middleware.DidNotReceive().PostEvent(Arg.Any<Middleware.EventWrapper>());
+            await middleware.DidNotReceive().SolveTicket(Arg.Any<Middleware.EventWrapper>());
         }
 
         private class AutoDataDomainAttribute : AutoDataAttribute

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -30,8 +30,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             zendesk.Tickets.First(x => x.Id == ticket.Id)
                 .Tags
-                .Should().NotContain("pending_middleware")
-                .And.Contain("sending_middleware");
+                .Should().NotContain("pending_middleware_solved")
+                .And.Contain("sending_middleware_solved");
         }
 
         [Theory, AutoDataDomain]
@@ -186,8 +186,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             zendesk.Tickets.First(x => x.Id == ticket.Id)
                 .Tags
-                .Should().NotContain("pending_middleware")
-                .And.NotContain("sending_middleware");
+                .Should().NotContain("pending_middleware_solved")
+                .And.NotContain("sending_middleware_solved");
         }
 
         [Theory, AutoDataDomain]

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
     public class Sharing_tickets
     {
         [Theory, AutoDataDomain]
-        public async Task Marks_ticket_as_sharing_before_sending_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket)
+        public async Task Marks_ticket_as_sharing_before_sending_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket)
         {
             zendesk.Tickets.Add(ticket);
             middleware.When(x => x.SolveTicket(Arg.Any<Middleware.EventWrapper>()))
@@ -35,7 +35,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
-        public async Task Sends_ticket_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket)
+        public async Task Sends_ticket_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket)
         {
             zendesk.Tickets.Add(ticket);
 
@@ -59,7 +59,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
-        public async Task Sends_ticket_to_middleware_with_comments([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket, Comment[] comments)
+        public async Task Sends_ticket_to_middleware_with_comments([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket, Comment[] comments)
         {
             zendesk.Tickets.Add(ticket);
             zendesk.AddComments(ticket, comments);
@@ -84,7 +84,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
-        public async Task Sends_ticket_to_middleware_with_requester([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket, User reporter)
+        public async Task Sends_ticket_to_middleware_with_requester([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket, User reporter)
         {
             ticket.RequesterId = reporter.Id;
             zendesk.Tickets.Add(ticket);
@@ -119,7 +119,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
-        public async Task Sends_ticket_to_middleware_with_organisation([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket, Organization org)
+        public async Task Sends_ticket_to_middleware_with_organisation([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket, Organization org)
         {
             ticket.OrganizationId = org.Id;
             zendesk.Tickets.Add(ticket);
@@ -152,7 +152,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
-        public async Task Sends_previously_failed_ticket_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending] Ticket ticket)
+        public async Task Sends_previously_failed_ticket_to_middleware([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket)
         {
             ticket.Tags.Remove("pending_middleware");
             ticket.Tags.Add("sending_middleware");
@@ -166,7 +166,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
-        public async Task Marks_ticket_as_shared([Frozen] FakeZendeskApi zendesk, Watcher sut, [Pending] Ticket ticket)
+        public async Task Marks_ticket_as_shared([Frozen] FakeZendeskApi zendesk, Watcher sut, [Pending(As.Solved)] Ticket ticket)
         {
             zendesk.Tickets.Add(ticket);
 

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
@@ -98,7 +98,7 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance.Fakes
 
         public Task<long[]> /*ISharingTickets.*/GetTicketsForSharing() => sharing.GetTicketsForSharing();
 
-        Task<Option<TicketResponse>> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
+        Task<Option<(TicketResponse, SharingReason)>> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
 
         Task ISharingTickets.MarkShared(Ticket ticket) => sharing.MarkShared(ticket);
 

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
@@ -100,8 +100,8 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance.Fakes
 
         Task<Option<(TicketResponse, SharingReason)>> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
 
-        Task ISharingTickets.MarkShared(Ticket ticket) => sharing.MarkShared(ticket);
+        Task ISharingTickets.MarkShared(Ticket ticket, SharingReason reason) => sharing.MarkShared(ticket, reason);
 
-        Task ISharingTickets.MarkSharing(Ticket t) => sharing.MarkSharing(t);
+        Task ISharingTickets.MarkSharing(Ticket t, SharingReason reason) => sharing.MarkSharing(t, reason);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/FakeZendesk.cs
@@ -98,10 +98,10 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance.Fakes
 
         public Task<long[]> /*ISharingTickets.*/GetTicketsForSharing() => sharing.GetTicketsForSharing();
 
-        Task<Option<(TicketResponse, SharingReason)>> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
+        Task<Option<SharedTicket>> ISharingTickets.GetTicketForSharing(long id) => sharing.GetTicketForSharing(id);
 
-        Task ISharingTickets.MarkShared(Ticket ticket, SharingReason reason) => sharing.MarkShared(ticket, reason);
+        Task ISharingTickets.MarkShared(SharedTicket share) => sharing.MarkShared(share);
 
-        Task ISharingTickets.MarkSharing(Ticket t, SharingReason reason) => sharing.MarkSharing(t, reason);
+        Task ISharingTickets.MarkSharing(SharedTicket share) => sharing.MarkSharing(share);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/MockMiddleware.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UserAcceptanceTests/Fakes/MockMiddleware.cs
@@ -36,8 +36,11 @@ namespace SFA.DAS.Zendesk.Monitor.Acceptance
 
         public string SubscriptionKey { get; set; }
 
-        public Task PostEvent([Body] Middleware.EventWrapper body)
-            => client.PostEvent(body);
+        public Task EscalateTicket([Body] EventWrapper body)
+            => client.EscalateTicket(body);
+
+        public Task SolveTicket([Body] Middleware.EventWrapper body)
+            => client.SolveTicket(body);
 
         public async Task<IReadOnlyList<Zendesk.Model.Ticket>> TicketEvents()
         {

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/IApi.cs
@@ -8,7 +8,10 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware
         [Query("subscription-key")]
         string SubscriptionKey { get; set; }
 
+        [Put("/ticket?escalate=true")]
+        Task EscalateTicket([Body] EventWrapper body);
+
         [Delete("/ticket")]
-        Task PostEvent([Body] EventWrapper body);
+        Task SolveTicket([Body] EventWrapper body);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Ticket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Ticket.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
         public string Description { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public string Subject { get; set; }
+        public object Via { get; set; }
         public Comments[] Comments { get; set; }
         public CustomField[] CustomFields { get; set; }
         public Organisation Organization { get; set; }

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System.Linq;
 
 namespace SFA.DAS.Zendesk.Monitor
@@ -18,6 +19,7 @@ namespace SFA.DAS.Zendesk.Monitor
                 .ForMember(x => x.Comments, x => x.Ignore())
                 .ForMember(x => x.Requester, x => x.Ignore())
                 .ForMember(x => x.Organization, x => x.Ignore())
+                .ForPath(x => x.Via, x => x.MapFrom(y => TranslateVia(y)))
                 ;
 
             CreateMap<Zendesk.Model.Comment, Middleware.Model.Comments>();
@@ -33,5 +35,18 @@ namespace SFA.DAS.Zendesk.Monitor
 
         private Zendesk.Model.User FindRequester(Zendesk.Model.TicketResponse response)
             => response.Users?.FirstOrDefault(x => x.Id == response.Ticket.RequesterId);
+
+        private string TranslateVia(Ticket y)
+        {
+            switch (y.Via?.Channel)
+            {
+                case "voice": return $"Phone call ({y.Via?.Source?.Rel})";
+                case "email": return "Mail";
+                case "chat": return "Chat";
+                case "web": return "Web Form";
+                
+                default: return y.Via?.Channel.ToLower();
+            }
+        }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System.Linq;
 
 namespace SFA.DAS.Zendesk.Monitor
@@ -36,17 +35,16 @@ namespace SFA.DAS.Zendesk.Monitor
         private Zendesk.Model.User FindRequester(Zendesk.Model.TicketResponse response)
             => response.Users?.FirstOrDefault(x => x.Id == response.Ticket.RequesterId);
 
-        private string TranslateVia(Ticket y)
+        private string TranslateVia(Zendesk.Model.Ticket y)
         {
-            switch (y.Via?.Channel)
+            return y.Via?.Channel switch
             {
-                case "voice": return $"Phone call ({y.Via?.Source?.Rel})";
-                case "email": return "Mail";
-                case "chat": return "Chat";
-                case "web": return "Web Form";
-                
-                default: return y.Via?.Channel.ToLower();
-            }
+                "voice" => $"Phone call ({y.Via?.Source?.Rel})",
+                "email" => "Mail",
+                "chat" => "Chat",
+                "web" => "Web Form",
+                _ => y.Via?.Channel.ToLower(),
+            };
         }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.Zendesk.Monitor
             await zendesk.MarkSharing(ticket.Ticket);
 
             var wrap = MapperConfig.Map<Middleware.EventWrapper>(ticket);
-            await middleware.PostEvent(wrap);
+            await middleware.SolveTicket(wrap);
 
             await zendesk.MarkShared(ticket.Ticket);
         }

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.Zendesk.Monitor
 
         private async Task ShareTicket((Zendesk.Model.TicketResponse ticket, SharingReason reason) share)
         {
-            await zendesk.MarkSharing(share.ticket.Ticket);
+            await zendesk.MarkSharing(share.ticket.Ticket, share.reason);
 
             var wrap = MapperConfig.Map<Middleware.EventWrapper>(share.ticket);
 

--- a/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Watcher.cs
@@ -48,8 +48,8 @@ namespace SFA.DAS.Zendesk.Monitor
                 default:
                     throw new Exception("");
             }
-
-            await zendesk.MarkShared(share.ticket.Ticket);
+ 
+            await zendesk.MarkShared(share.ticket.Ticket, share.reason);
         }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/IApiExtensions.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/IApiExtensions.cs
@@ -19,5 +19,8 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
         public static Task<TicketResponse> GetTicketWithRequiredSideloads(this IApi api, long id)
             => api.GetTicketWithSideloads(id, RequiredSideloads);
+
+        public static async Task<Comment[]> GetTicketComments(this IApi api, Ticket ticket)
+            => (await api.GetTicketComments(ticket.Id))?.Comments;
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
@@ -10,8 +10,8 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
         Task<Option<(TicketResponse, SharingReason)>> GetTicketForSharing(long id);
 
-        Task MarkSharing(Ticket t);
+        Task MarkSharing(Ticket t, SharingReason reason);
 
-        Task MarkShared(Ticket t);
+        Task MarkShared(Ticket t, SharingReason reason);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
     {
         Task<long[]> GetTicketsForSharing();
 
-        Task<Option<TicketResponse>> GetTicketForSharing(long id);
+        Task<Option<(TicketResponse, SharingReason)>> GetTicketForSharing(long id);
 
         Task MarkSharing(Ticket t);
 

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/ISharingTickets.cs
@@ -8,10 +8,10 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
     {
         Task<long[]> GetTicketsForSharing();
 
-        Task<Option<(TicketResponse, SharingReason)>> GetTicketForSharing(long id);
+        Task<Option<SharedTicket>> GetTicketForSharing(long id);
 
-        Task MarkSharing(Ticket t, SharingReason reason);
+        Task MarkSharing(SharedTicket share);
 
-        Task MarkShared(Ticket t, SharingReason reason);
+        Task MarkShared(SharedTicket share);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
@@ -1,0 +1,36 @@
+﻿using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
+using System;
+
+namespace SFA.DAS.Zendesk.Monitor.Zendesk
+{
+    public class SharedTicket
+    {
+        public SharingReason Reason { get; }
+
+        public TicketResponse Response { get; }
+
+        public SharedTicket(SharingReason reason, TicketResponse response)
+        {
+            if (reason > SharingReason.Escalated)
+                throw new ArgumentOutOfRangeException("Undeclared SharingReason found.");
+
+            Reason = reason;
+            Response = response;
+        }
+
+        public T Switch<T>(Func<bool, T> solved, Func<bool, T> escalated)
+        {
+            switch(Reason)
+            {
+                case SharingReason.Solved:
+                    return solved(true);
+
+                case SharingReason.Escalated:
+                    return escalated(true);
+
+                default:
+                    throw new InvalidOperationException("Undeclared SharingReason found in Switch");
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
         public SharedTicket(SharingReason reason, TicketResponse response)
         {
             if (reason > SharingReason.Escalated)
-                throw new ArgumentOutOfRangeException("Undeclared SharingReason found.");
+                throw new ArgumentOutOfRangeException(nameof(reason), reason, "Undeclared SharingReason found.");
 
             Reason = reason;
             Response = response;
@@ -20,17 +20,12 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
         public T Switch<T>(Func<bool, T> solved, Func<bool, T> escalated)
         {
-            switch(Reason)
+            return Reason switch
             {
-                case SharingReason.Solved:
-                    return solved(true);
-
-                case SharingReason.Escalated:
-                    return escalated(true);
-
-                default:
-                    throw new InvalidOperationException("Undeclared SharingReason found in Switch");
-            }
+                SharingReason.Solved => solved(true),
+                SharingReason.Escalated => escalated(true),
+                _ => throw new InvalidOperationException("Undeclared SharingReason found in Switch"),
+            };
         }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingReason.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingReason.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Zendesk
+{
+    public enum SharingReason
+    {
+        Solved,
+        Escalated,
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
@@ -16,16 +16,19 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
     public class SharingTickets : ISharingTickets
     {
-        const string pendingTag = "pending_middleware";
-        const string sendingTag = "sending_middleware";
+        const string pendingTag = "pending";
+        const string sendingTag = "sending";
 
-        private readonly string[] Tags = new[]
+        private static readonly string[] Tags = new[]
         {
-            $"{pendingTag}_{SharingReason.Solved.ToString().ToLower()}", 
-            $"{sendingTag}_{SharingReason.Solved.ToString().ToLower()}", 
-            $"{pendingTag}_{SharingReason.Escalated.ToString().ToLower()}", 
-            $"{sendingTag}_{SharingReason.Escalated.ToString().ToLower()}", 
+            MakeTag("pending", SharingReason.Solved),
+            MakeTag("sending", SharingReason.Solved),
+            MakeTag("pending", SharingReason.Escalated),
+            MakeTag("sending", SharingReason.Escalated),
         };
+
+        private static string MakeTag(string state, SharingReason reason) =>
+            $"{state}_middleware_{reason.ToString().ToLower()}";
 
         private readonly IApi api;
 
@@ -82,16 +85,16 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
         private bool TicketContainsSharingTag(Ticket ticket) =>
             GetSharingTagsInTicket(ticket).Any();
 
-        public Task MarkSharing(Ticket t)
+        public Task MarkSharing(Ticket t, SharingReason reason)
         {
-            t.Tags.Remove(pendingTag);
-            t.Tags.Add(sendingTag);
+            t.Tags.Remove(MakeTag(pendingTag, reason));
+            t.Tags.Add(MakeTag(sendingTag, reason));
             return api.PutTicket(t);
         }
 
-        public Task MarkShared(Ticket t)
+        public Task MarkShared(Ticket t, SharingReason reason)
         {
-            t.Tags.Remove(sendingTag);
+            t.Tags.Remove(MakeTag(sendingTag, reason));
             return api.PutTicket(t);
         }
     }


### PR DESCRIPTION
Tickets that are escalated must be sent to a different endpoint in the middleware.  We add a suffix to the pending/sending tags - `pending_middleware_solved` and `pending_middleware_escalated` to differentiate between the action required.

Escalated tickets also require the `Via` property to be passed over, specifying the channel the ticket arrived via - e.g. "Email" / "Phone" / etc.