### PR TITLE
Send comment attachments to middleware

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -106,6 +106,34 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         }
 
         [Theory, AutoDataDomain]
+        public async Task Sends_ticket_to_middleware_with_attachments([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket, Comment[] comments)
+        {
+            zendesk.Tickets.Add(ticket);
+            zendesk.AddComments(ticket, comments);
+
+            await sut.ShareTicket(ticket.Id);
+
+            var expected = new
+            {
+                Ticket = new
+                {
+                    Comments = comments.Select(c =>
+                    new
+                    {
+                        c.Id,
+                        Attachments = c.Attachments.Select(a => new
+                        {
+                            a.FileName,
+                            Url = a.ContentUrl.ToString(),
+                        }),
+                    }),
+                }
+            };
+
+            await middleware.Received().SolveTicket(Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(expected)));
+        }
+
+        [Theory, AutoDataDomain]
         public async Task Sends_ticket_to_middleware_with_requester([Frozen] FakeZendeskApi zendesk, [Frozen] Middleware.IApi middleware, Watcher sut, [Pending(As.Solved)] Ticket ticket, User reporter)
         {
             ticket.RequesterId = reporter.Id;

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -124,7 +124,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                         Attachments = c.Attachments.Select(a => new
                         {
                             a.FileName,
-                            Url = a.ContentUrl.ToString(),
+                            Url = a.ContentUrl,
                         }),
                     }),
                 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Attachment.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Attachment.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+{
+    public class Attachment
+    {
+        public string FileName { get; set; }
+        public string Url { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Attachment.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Attachment.cs
@@ -1,8 +1,10 @@
-﻿namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
+﻿using System;
+
+namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
 {
     public class Attachment
     {
         public string FileName { get; set; }
-        public string Url { get; set; }
+        public Uri Url { get; set; }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Comments.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Comments.cs
@@ -7,5 +7,6 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
         public long Id { get; set; }
         public string Body { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
+        public Attachment[] Attachments { get; set; }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -22,6 +22,9 @@ namespace SFA.DAS.Zendesk.Monitor
                 ;
 
             CreateMap<Zendesk.Model.Comment, Middleware.Model.Comments>();
+            CreateMap<Zendesk.Model.Attachment, Middleware.Model.Attachment>()
+                .ForMember(x => x.Url, x => x.MapFrom(y => y.ContentUrl))
+                ;
             CreateMap<Zendesk.Model.Field, Middleware.Model.CustomField>();
             CreateMap<Zendesk.Model.User, Middleware.Model.User>();
             CreateMap<Zendesk.Model.Organization, Middleware.Model.Organisation>();

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Attachment.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Attachment.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace SFA.DAS.Zendesk.Monitor.Zendesk.Model
+{
+    public class Attachment
+    {
+        public long? Id { get; set; }
+        public string FileName { get; set; }
+        public Uri ContentUrl { get; set; }
+        public string ContentType { get; set; }
+        public long? Size { get; set; }
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Comment.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Comment.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk.Model
 
         public bool? Public { get; set; }
 
-        public object[] Attachments { get; set; }
+        public Attachment[] Attachments { get; set; }
 
         public Via Via { get; set; }
 


### PR DESCRIPTION
Attachments to comments should be sent to middleware with the comments themselves.