### PR TITLE
🐛Remove duplicate pending/sending tags

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -1,4 +1,4 @@
- using AutoFixture;
+using AutoFixture;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Xunit2;
 using FluentAssertions;
@@ -28,9 +28,9 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             ticket.Tags.Add($"pending_middleware_{state}".ToLower());
             zendesk.Tickets.Add(ticket);
             middleware.When(x => x.SolveTicket(Arg.Any<Middleware.EventWrapper>()))
-                .Do(x => { throw new Exception("Stop test at Middleware step"); });
+                .Do(_ => throw new Exception("Stop test at Middleware step"));
             middleware.When(x => x.EscalateTicket(Arg.Any<Middleware.EventWrapper>()))
-                .Do(x => { throw new Exception("Stop test at Middleware step"); });
+                .Do(_ => throw new Exception("Stop test at Middleware step"));
 
             try
             {
@@ -233,6 +233,21 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         [Theory, AutoDataDomain]
         public async Task Marks_ticket_as_shared([Frozen] FakeZendeskApi zendesk, Watcher sut, [Pending(As.Solved)] Ticket ticket)
         {
+            zendesk.Tickets.Add(ticket);
+
+            await sut.ShareTicket(ticket.Id);
+
+            zendesk.Tickets.First(x => x.Id == ticket.Id)
+                .Tags
+                .Should().NotContain("pending_middleware_solved")
+                .And.NotContain("sending_middleware_solved");
+        }
+
+        [Theory, AutoDataDomain]
+        public async Task Marks_ticket_as_shared_with_duplicate_tags([Frozen] FakeZendeskApi zendesk, Watcher sut, [Pending(As.Solved)] Ticket ticket)
+        {
+            ticket.Tags.Add("sending_middleware_solved");
+            ticket.Tags.Add("pending_middleware_solved");
             zendesk.Tickets.Add(ticket);
 
             await sut.ShareTicket(ticket.Id);

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Ticket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/Model/Ticket.cs
@@ -80,5 +80,11 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk.Model
         public bool? AllowChannelback { get; set; }
 
         public bool? AllowAttachments { get; set; }
+
+        public void RemoveTag(string tag)
+            => Tags.RemoveAll(x => x == tag);
+
+        public void AddTag(string tag)
+            => Tags.Add(tag);
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
@@ -65,8 +65,8 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
         
         private Task MarkSharing(Ticket t, SharingReason reason)
         {
-            t.Tags.Remove(MakeTag(SharingState.Pending, reason));
-            t.Tags.Add(MakeTag(SharingState.Sending, reason));
+            t.RemoveTag(MakeTag(SharingState.Pending, reason));
+            t.AddTag(MakeTag(SharingState.Sending, reason));
             return api.PutTicket(t);
         }
 
@@ -75,7 +75,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
         private Task MarkShared(Ticket t, SharingReason reason)
         {
-            t.Tags.Remove(MakeTag(SharingState.Sending, reason));
+            t.RemoveTag(MakeTag(SharingState.Sending, reason));
             return api.PutTicket(t);
         }
 


### PR DESCRIPTION
Every 30 minutes the Watcher looks for tickets that have been marked (by a tag) as needing to be sent to the middleware.  It then adds a "sending" tag, sends them over, and removes the "sending" tag.   

Occasionally, for some reason a ticket has two such tags, and Zendesk allows but hides duplicate tags on a ticket.

This results in the Watcher seeing the ticket, add a (duplicate) sending tag, then removing the (duplicate) sending tag - but not the original sending tag.

Therefore the ticket is never fully marked as having be sent.