### PR TITLE
Use API that is being changed in another PR.

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -354,6 +354,12 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             await middleware.DidNotReceive().SolveTicket(Arg.Any<Middleware.EventWrapper>());
         }
 
+        [Theory, AutoDataDomain]
+        public async Task Github_protection_stops_merging_conflicting_prs([Frozen] Zendesk.IApi zendesk, Ticket ticket)
+        {
+            await zendesk.PutTicket(ticket.Id, new TicketRequest { });
+        }
+
         private class AutoDataDomainAttribute : AutoDataAttribute
         {
             public AutoDataDomainAttribute() : base(() => Customise())


### PR DESCRIPTION
Github should prevent this from being merged once the other PR is merged, even though these checks have passed.