### PR TITLE
🐛 Solved tickets notify middleware again

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Fakes/FakeZendeskApi.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Fakes/FakeZendeskApi.cs
@@ -77,7 +77,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
         public Task PutTicket([Path] long id, [Body] TicketRequest ticket)
             => Task.CompletedTask;
 
-        internal void AddComments(Ticket ticket, Comment[] comments)
+        internal void AddComments(Ticket ticket, params Comment[] comments)
             => TicketComments(ticket.Id).AddRange(comments);
 
         internal void AddComments(Ticket ticket, AuditedComment[] comments)

--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/Sharing_tickets.cs
@@ -86,7 +86,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             [Frozen] FakeZendeskApi zendesk,
             [Frozen] Middleware.IApi middleware,
             [Frozen] AuditedComment comment,
-            [Pending.Solved] Ticket ticket,
+            [Pending.Escalated] Ticket ticket,
             Watcher sut
                                                                                       )
         {
@@ -98,7 +98,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             await sut.ShareTicket(ticket.Id);
 
             // Then
-            await middleware.DidNotReceive().SolveTicket(Arg.Any<Middleware.EventWrapper>());
+            await middleware.DidNotReceive().EscalateTicket(Arg.Any<Middleware.EventWrapper>());
         }
 
         [Theory, AutoDataDomain]
@@ -107,7 +107,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             [Frozen] Middleware.IApi middleware,
             Watcher sut,
             [Frozen] AuditedComment comment,
-            [Pending.Solved] Ticket ticket)
+            [Pending.Escalated] Ticket ticket)
         {
             // Given
             var auditTagEvent = comment.AuditTagEvent.Value = "escalated_tag";
@@ -119,7 +119,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             // Then
             var mwt = new { Ticket = new { Comments = new[] { new { comment.Id } } } };
 
-            await middleware.Received().SolveTicket(
+            await middleware.Received().EscalateTicket(
                 Verify.That<Middleware.EventWrapper>(x => x.Should().BeEquivalentTo(mwt)));
         }
 
@@ -149,7 +149,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             [Frozen] FakeZendeskApi zendesk,
             [Frozen] Middleware.IApi middleware,
             Watcher sut,
-            [Pending.Solved(addComment: false)] Ticket ticket,
+            [Pending.Solved] Ticket ticket,
             AuditedComment[] comments)
         {
             // Given
@@ -184,7 +184,7 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
             [Frozen] FakeZendeskApi zendesk,
             [Frozen] Middleware.IApi middleware,
             Watcher sut,
-            [Pending.Solved(addComment: false)] Ticket ticket,
+            [Pending.Solved] Ticket ticket,
             AuditedComment[] comments)
         {
             // Given

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
@@ -36,7 +36,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
             return
                 from reason in shareReason
                 from responseWithComments in shareReason.MapAsync(_ => loadComments(response))
-                where TicketWasShared(responseWithComments)
+                where TicketWasShared(responseWithComments, reason)
                 select new SharedTicket(reason, responseWithComments);
 
             static string LastWord(string tag)
@@ -48,8 +48,9 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
                 t => t.EndsWith(SharingReason.Solved.AsTag())
                   || t.EndsWith(SharingReason.Escalated.AsTag()));
 
-        private static bool TicketWasShared(TicketResponse response)
-            => response.Comments.Any();
+        private static bool TicketWasShared(TicketResponse response, SharingReason reason)
+            => reason == SharingReason.Solved
+            || (reason == SharingReason.Escalated && response.Comments.Any());
 
         private SharedTicket(SharingReason reason, TicketResponse response)
         {


### PR DESCRIPTION
Fix a regression introduced in #29 where `solved` tickets are no longer sent to the middleware.