### PR TITLE
Encapsulate sharedticket

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor/SFA.DAS.Zendesk.Monitor.csproj
+++ b/src/SFA.DAS.Zendesk.Monitor/SFA.DAS.Zendesk.Monitor.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="LanguageExt.Core" Version="3.3.28" />
+    <PackageReference Include="LanguageExt.Core" Version="3.4.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/CartesianProduct.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/CartesianProduct.cs
@@ -1,0 +1,47 @@
+﻿using LanguageExt;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SFA.DAS.Zendesk.Monitor.Zendesk
+{
+    public static class CartesianProduct
+    {
+        /// <summary>
+        /// <para>
+        /// Calculate the set of all ordered pairs (a,b) 
+        /// where a is in A and b is in B.
+        /// </para>
+        /// <para>
+        /// The Cartesian Product of the sets of playing card ranks
+        /// {A, K, Q, J, 10, 9, 8, 7, 6, 5, 4, 3, 2}
+        /// and playing card suits {♠, ♥, ♦, ♣}
+        /// forms a complete deck of cards {(A,♠), (A,♥), ..., (2, ♦), (2, ♣)}
+        /// </para>
+        /// </summary>
+        public static CartesianProduct<TA, TB> OfEnums<TA, TB>()
+            where TA : struct, Enum
+            where TB : struct, Enum
+            => new CartesianProduct<TA, TB>(GetValues<TA>(), GetValues<TB>());
+
+        public static T[] GetValues<T>() where T : struct, Enum
+            => (T[])Enum.GetValues(typeof(T));
+    }
+
+    public class CartesianProduct<TA, TB>
+    {
+        private readonly IEnumerable<TA> A;
+        private readonly IEnumerable<TB> B;
+
+        public CartesianProduct(IEnumerable<TA> sequence1, IEnumerable<TB> sequence2)
+        {
+            A = sequence1;
+            B = sequence2;
+        }
+
+        public IEnumerable<TResult> Using<TResult>(Func<TA, TB, TResult> combine)
+            => from a in A
+               from b in B
+               select combine(a, b);
+    }
+}

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
@@ -1,15 +1,62 @@
-﻿using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
+﻿using LanguageExt;
+using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using static LanguageExt.Prelude;
 
 namespace SFA.DAS.Zendesk.Monitor.Zendesk
 {
-    public class SharedTicket
+    public sealed class SharedTicket
     {
         public SharingReason Reason { get; }
 
         public TicketResponse Response { get; }
 
-        public SharedTicket(SharingReason reason, TicketResponse response)
+        public static OptionAsync<SharedTicket> Create(
+            TicketResponse response,
+            Func<TicketResponse, Task<TicketResponse>> loadComments)
+        {
+            if (response == null) throw new ArgumentNullException(nameof(response));
+            if (loadComments == null) throw new ArgumentNullException(nameof(response));
+
+            return ReasonForSharing(response, loadComments);
+        }
+
+        private static OptionAsync<SharedTicket> ReasonForSharing(
+            TicketResponse response,
+            Func<TicketResponse, Task<TicketResponse>> loadComments)
+        {
+            var shareReason =
+                GetSharingTagsInTicket(response.Ticket).ToOption()
+                .Map(LastWord)
+                .Bind(parseEnum<SharingReason>).ToAsync();
+
+            return
+                from reason in shareReason
+                from responseWithComments in shareReason.MapAsync(_ => loadComments(response))
+                where TicketWasShared(responseWithComments)
+                select new SharedTicket(reason, responseWithComments);
+
+            static string LastWord(string tag)
+                => tag?.Split('_').LastOrDefault() ?? "";
+
+            static Option<TEnum> parseEnum<TEnum>(string value) where TEnum : struct
+                => Enum.TryParse<TEnum>(value, true, out TEnum result)
+                    ? Some(result)
+                    : None;
+        }
+
+        private static IEnumerable<string> GetSharingTagsInTicket(Ticket ticket)
+            => ticket.Tags.Where(t => t.EndsWith("_middleware_solved")
+            || t.EndsWith("_middleware_escalated"));
+
+        private static bool TicketWasShared(TicketResponse response)
+            => response.Comments.Any();
+
+
+        private SharedTicket(SharingReason reason, TicketResponse response)
         {
             if (reason > SharingReason.Escalated)
                 throw new ArgumentOutOfRangeException(nameof(reason), reason, "Undeclared SharingReason found.");

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
             var shareReason =
                 GetSharingTagsInTicket(response.Ticket).ToOption()
                 .Map(LastWord)
-                .Bind(parseEnum<SharingReason>).ToAsync();
+                .Bind(parseEnumIgnoreCase<SharingReason>).ToAsync();
 
             return
                 from reason in shareReason
@@ -41,11 +41,6 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
             static string LastWord(string tag)
                 => tag?.Split('_').LastOrDefault() ?? "";
-
-            static Option<TEnum> parseEnum<TEnum>(string value) where TEnum : struct
-                => Enum.TryParse<TEnum>(value, true, out TEnum result)
-                    ? Some(result)
-                    : None;
         }
 
         private static IEnumerable<string> GetSharingTagsInTicket(Ticket ticket)

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharedTicket.cs
@@ -44,12 +44,12 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
         }
 
         private static IEnumerable<string> GetSharingTagsInTicket(Ticket ticket)
-            => ticket.Tags.Where(t => t.EndsWith("_middleware_solved")
-            || t.EndsWith("_middleware_escalated"));
+            => ticket.Tags.Where(
+                t => t.EndsWith(SharingReason.Solved.AsTag())
+                  || t.EndsWith(SharingReason.Escalated.AsTag()));
 
         private static bool TicketWasShared(TicketResponse response)
             => response.Comments.Any();
-
 
         private SharedTicket(SharingReason reason, TicketResponse response)
         {

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingReason.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingReason.cs
@@ -5,4 +5,10 @@
         Solved,
         Escalated,
     }
+
+    public static class SharingReasonExtensions
+    {
+        public static string AsTag(this SharingReason reason)
+            => $"middleware_{reason}".ToLower();
+    }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
@@ -55,9 +55,6 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
                    e.Value?.Contains("escalated_tag") == true;
         }
 
-        private static IEnumerable<string> GetSharingTagsInTicket(Ticket ticket) =>
-            ticket.Tags.Intersect(AllSharingTags);
-
         public async Task<long[]> GetTicketsForSharing()
         {
             var search = string.Join(" ", AllSharingTags.Select(x => $"tags:{x}"));
@@ -70,6 +67,9 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
 
         private bool TicketContainsSharingTag(Ticket ticket) =>
             GetSharingTagsInTicket(ticket).Any();
+
+        private static IEnumerable<string> GetSharingTagsInTicket(Ticket ticket) =>
+            ticket.Tags.Intersect(AllSharingTags);
 
         public Task MarkSharing(SharedTicket share)
         {
@@ -108,6 +108,6 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
                 .Using(MakeTag).ToArray();
 
         private static string MakeTag(SharingState state, SharingReason reason) =>
-            $"{state}_middleware_{reason}".ToLower();
+            $"{state}_{reason.AsTag()}".ToLower();
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Zendesk/SharingTickets.cs
@@ -1,4 +1,4 @@
-﻿using LanguageExt;
+using LanguageExt;
 using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System;
 using System.Collections.Generic;
@@ -102,13 +102,10 @@ namespace SFA.DAS.Zendesk.Monitor.Zendesk
             Sending,
         }
 
-        private static readonly string[] AllSharingTags = new[]
-        {
-            MakeTag(SharingState.Pending, SharingReason.Solved),
-            MakeTag(SharingState.Sending, SharingReason.Solved),
-            MakeTag(SharingState.Pending, SharingReason.Escalated),
-            MakeTag(SharingState.Sending, SharingReason.Escalated),
-        };
+        private static readonly string[] AllSharingTags =
+            CartesianProduct
+                .OfEnums<SharingState, SharingReason>()
+                .Using(MakeTag).ToArray();
 
         private static string MakeTag(SharingState state, SharingReason reason) =>
             $"{state}_middleware_{reason}".ToLower();


### PR DESCRIPTION
The concepts of sharing reason and sharing state are becoming too entwined inside `SharingTicket.cs`.  This PR separates those concepts more fully, pushing the reason fully into `SharedTicket` and the state and process of sharing into `SharingTicket`