### PR TITLE
AD-1746 - ✨Report tickets via Twitter as coming via email

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
@@ -17,8 +17,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
         public static IEnumerable<object[]> ViaTestData => new List<object[]>
         {
-            new object[] 
-            { 
+            new object[]
+            {
                 new Via
                 {
                     Channel = "voice",
@@ -26,8 +26,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 },
                 "Phone call (inbound)"
             },
-            new object[] 
-            { 
+            new object[]
+            {
                 new Via
                 {
                     Channel = "voice",
@@ -35,8 +35,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 },
                 "Voicemail"
             },
-            new object[] 
-            { 
+            new object[]
+            {
                 new Via
                 {
                     Channel = "voice",
@@ -44,8 +44,8 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 },
                 "Phone call (outbound)"
             },
-            new object[] 
-            { 
+            new object[]
+            {
                 new Via {Channel = "email"},
                 "Mail"
             },
@@ -54,10 +54,15 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 new Via { Channel = "chat" },
                 "Chat"
             },
-            new object[] 
-            { 
+            new object[]
+            {
                 new Via { Channel = "web" },
                 "Web Form"
+            },
+            new object[]
+            {
+                new Via { Channel = "twitter" },
+                "Mail"
             },
         };
 

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -59,9 +59,10 @@ namespace SFA.DAS.Zendesk.Monitor
         {
             return (y.Via?.Channel, y.Via?.Source?.Rel) switch
             {
-                ("voice", "voicemail") => $"Voicemail",
+                ("voice", "voicemail") => "Voicemail",
                 ("voice", _) => $"Phone call ({y.Via?.Source?.Rel})",
                 ("email", _) => "Mail",
+                ("twitter", _) => "Mail",
                 ("chat", _) => "Chat",
                 ("web", _) => "Web Form",
                 _ => y.Via?.Channel.ToLower(),


### PR DESCRIPTION
Downstream systems have no concept of Twitter, so treat twitter as an equivalent channel to email.