### PR TITLE
Fix SpecFlow project build environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,8 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: Build
+  env:
+    MSBUILDSINGLELOADCONTEXT: 1
   inputs:
     projects: 'src/**/*.csproj'
     arguments: '--configuration $(buildConfiguration) --no-restore'


### PR DESCRIPTION
Set Environment variable to get old MSBuild behaviour as per https://github.com/SpecFlowOSS/SpecFlow/issues/1912