### PR TITLE
Map "API" source to email for middleware

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
@@ -64,6 +64,11 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
                 new Via { Channel = "twitter" },
                 "Mail"
             },
+            new object[]
+            {
+                new Via { Channel = "api" },
+                "Mail"
+            },
         };
 
         [Theory, MemberData(nameof(ViaTestData))]

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -63,6 +63,7 @@ namespace SFA.DAS.Zendesk.Monitor
                 ("voice", _) => $"Phone call ({y.Via?.Source?.Rel})",
                 ("email", _) => "Mail",
                 ("twitter", _) => "Mail",
+                ("api", _) => "Mail",
                 ("chat", _) => "Chat",
                 ("web", _) => "Web Form",
                 _ => y.Via?.Channel.ToLower(),


### PR DESCRIPTION
This enables tickets created by the API to be sent to the middleware, which in turn paves the way for automated end-to-end behaviour tests to augment the existing automated integration tests.