### PR TITLE
AD-2112 Specify a destination the middleware should route the ticket to

### DIFF
--- a/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
+++ b/src/SFA.DAS.Zendesk.Monitor.UnitTests/Tests/MappingProfileTests.cs
@@ -82,5 +82,24 @@ namespace SFA.DAS.Zendesk.Monitor.UnitTests
 
             mapped.Via.Should().Be(viaText);
         }
+
+        [Theory]
+        [InlineData("middleware_destination_itsm", "itsm")]
+        [InlineData("middleware_destination_pcrm", "pcrm")]
+        [InlineData("some_other_tag", "itsm")] // default to "itsm"
+        [InlineData("middleware_destination_", "")]  // ability to "unset" destination
+        public void TestDestinationMapping(string tag, string destination)
+        {
+            var mapper = new MapperConfiguration(cfg => cfg.AddProfile<TicketProfile>()).CreateMapper();
+
+            var ticket = new Ticket
+            {
+                Tags = new List<string> { tag },
+            };
+
+            var mapped = mapper.Map<Middleware.Model.Ticket>(ticket);
+
+            mapped.Destination.Should().Be(destination);
+        }
     }
 }

--- a/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Ticket.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/Middleware/Model/Ticket.cs
@@ -17,6 +17,7 @@ namespace SFA.DAS.Zendesk.Monitor.Middleware.Model
         public CustomField[] CustomFields { get; set; }
         public Organisation Organization { get; set; }
         public User Requester { get; set; }
+        public string Destination { get; set; }
 
         public override string ToString()
             => JsonConvert.SerializeObject(this, Formatting.Indented);

--- a/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
+++ b/src/SFA.DAS.Zendesk.Monitor/TicketProfile.cs
@@ -1,6 +1,8 @@
 using AutoMapper;
+using SFA.DAS.Zendesk.Monitor.Zendesk.Model;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SFA.DAS.Zendesk.Monitor
 {
@@ -16,6 +18,7 @@ namespace SFA.DAS.Zendesk.Monitor
                 ;
 
             CreateMap<Zendesk.Model.Ticket, Middleware.Model.Ticket>()
+                .ForMember(dest => dest.Destination, src => src.MapFrom(p => FindDestination(p)))
                 .ForMember(dest => dest.Comments, src => src.Ignore())
                 .ForMember(dest => dest.Requester, src => src.Ignore())
                 .ForMember(dest => dest.Organization, src => src.Ignore())
@@ -48,6 +51,12 @@ namespace SFA.DAS.Zendesk.Monitor
                 .ForAllMembers(src => src.NullSubstitute(""))
                 ;
         }
+
+        private static string FindDestination(Ticket p) =>
+            p.Tags
+                ?.Find(t => t.StartsWith("middleware_destination_"))
+                ?.Split("_").Last()
+            ?? "itsm";
 
         private static Zendesk.Model.Organization? FindOrganisation(Zendesk.Model.TicketResponse response)
             => response.Organizations?.FirstOrDefault(x => x.Id == response.Ticket.OrganizationId);


### PR DESCRIPTION
When there are multiple possible systems the ticket would be integrated with, Zendesk has the ability to select which system is the destination.  Specifying a tag `middleware_destination_xxxx` will result in the middleware payload containing the field `destination` with the value `xxxx`.